### PR TITLE
Moved Flush after messaging shutdown

### DIFF
--- a/oortstore/groupstore.go
+++ b/oortstore/groupstore.go
@@ -305,8 +305,8 @@ func (s *OortGroupStore) Stop() {
 		return
 	}
 	s.vs.DisableAll()
-	s.vs.Flush()
 	s.t.Shutdown()
+	s.vs.Flush()
 	s.stopped = true
 	s.Unlock()
 	log.Println(s.vs.Stats(true))

--- a/oortstore/valuestore.go
+++ b/oortstore/valuestore.go
@@ -268,8 +268,8 @@ func (s *OortValueStore) Stop() {
 		return
 	}
 	s.vs.DisableAll()
-	s.vs.Flush()
 	s.t.Shutdown()
+	s.vs.Flush()
 	s.stopped = true
 	s.Unlock()
 	log.Println(s.vs.Stats(true))


### PR DESCRIPTION
Seems safer, as there are some incoming messages than can be processed
even if user writes are disabled.
