### PR TITLE
Pull ListenAddr from ring

### DIFF
--- a/oort/oort.go
+++ b/oort/oort.go
@@ -89,6 +89,13 @@ func (o *Server) GetLocalID() uint64 {
 	return o.localID
 }
 
+// GetListenAddr returns the current localnode.address2 instance
+func (o *Server) GetListenAddr() string {
+	o.RLock()
+	defer o.RUnlock()
+	return o.ring.LocalNode().Address(2)
+}
+
 func (o *Server) CmdCtrlLoopActive() bool {
 	o.RLock()
 	defer o.RUnlock()

--- a/oortstore/groupstore.go
+++ b/oortstore/groupstore.go
@@ -421,11 +421,15 @@ func (s *OortGroupStore) ListenAndServe() {
 		s.grpcStopping = false
 		for {
 			var err error
-			l, err := net.Listen("tcp", s.Config.ListenAddr)
+			listenAddr := s.oort.GetListenAddr()
+			if listenAddr == "" {
+				log.Fatalln("No listen address specified in ring at address2")
+			}
+			l, err := net.Listen("tcp", listenAddr)
 			if err != nil {
 				log.Fatalln("Unable to bind to address:", err)
 			}
-			log.Println("GroupStore bound to:", s.Config.ListenAddr)
+			log.Println("GroupStore bound to:", listenAddr)
 			var opts []grpc.ServerOption
 			creds := credentials.NewTLS(s.serverTLSConfig)
 			opts = []grpc.ServerOption{grpc.Creds(creds)}

--- a/oortstore/valuestore.go
+++ b/oortstore/valuestore.go
@@ -316,11 +316,15 @@ func (s *OortValueStore) ListenAndServe() {
 		for {
 			s.Lock()
 			var err error
-			l, err := net.Listen("tcp", s.Config.ListenAddr)
+			listenAddr := s.oort.GetListenAddr()
+			if listenAddr == "" {
+				log.Fatalln("No listen address specified in ring at address2")
+			}
+			l, err := net.Listen("tcp", listenAddr)
 			if err != nil {
 				log.Fatalln("Unable to bind to address:", err)
 			}
-			log.Println("ValueStore bound to:", s.Config.ListenAddr)
+			log.Println("ValueStore bound to:", listenAddr)
 			var opts []grpc.ServerOption
 			creds := credentials.NewTLS(s.serverTLSConfig)
 			opts = []grpc.ServerOption{grpc.Creds(creds)}


### PR DESCRIPTION
Switches oort-valued and groupd to pull their primary ListenAddr for the API (i.e. the store) from the ring. This assumes that the ring entry contains an address2 entry thats the ip:port the service should be listening on.