### PR TITLE
Streamlining a few things

### DIFF
--- a/oort/config.go
+++ b/oort/config.go
@@ -142,10 +142,23 @@ func (o *Server) ObtainConfig() (err error) {
 	return nil
 }
 
-//TODO: need to remove the hack to add IAD3 identifier
+//TODO: need to remove the hack to add IAD3 identifier -- What hack? Not sure
+// what this refers to.
 func genServiceID(service, name, proto string) (string, error) {
 	h, _ := os.Hostname()
 	d := strings.SplitN(h, ".", 2)
+	// All-In-One defaults
+	if strings.HasSuffix(d[0], "-aio") {
+		// TODO: Not sure about name, proto -- are those ever *not* "syndicate"
+		// and "tcp"?
+		switch service {
+		case "value":
+			return h + ":8443", nil
+		case "group":
+			return h + ":8444", nil
+		}
+		panic("Unknown service " + service)
+	}
 	if len(d) != 2 {
 		return "", fmt.Errorf("Unable to determine FQDN, only got short name.")
 	}

--- a/oort/config.go
+++ b/oort/config.go
@@ -90,7 +90,7 @@ func (o *Server) ObtainConfig() (err error) {
 		s := &srvconf.SRVLoader{
 			SyndicateURL: e.Get("SYNDICATE_OVERRIDE"),
 		}
-		s.Record, err = genServiceID(o.serviceName, "syndicate", "tcp")
+		s.Record, err = GenServiceID(o.serviceName, "syndicate", "tcp")
 		if err != nil {
 			if e.Get("SYNDICATE_OVERRIDE") == "" {
 				log.Println(err)
@@ -144,7 +144,7 @@ func (o *Server) ObtainConfig() (err error) {
 
 //TODO: need to remove the hack to add IAD3 identifier -- What hack? Not sure
 // what this refers to.
-func genServiceID(service, name, proto string) (string, error) {
+func GenServiceID(service, name, proto string) (string, error) {
 	h, _ := os.Hostname()
 	d := strings.SplitN(h, ".", 2)
 	// All-In-One defaults

--- a/packaging/root/usr/share/oort/systemd/oort-groupd.service
+++ b/packaging/root/usr/share/oort/systemd/oort-groupd.service
@@ -11,7 +11,7 @@ After=syslog.target network.target
 # http://0pointer.de/public/systemd-man/systemd.exec.html
 [Service]
 Type=simple
-EnvironmentFile=/etc/default/oort-groupd
+EnvironmentFile=-/etc/default/oort-groupd
 ExecStart=/root/go/bin/oort-groupd
 
 # it could take a long time to flush data to disk

--- a/packaging/root/usr/share/oort/systemd/oort-valued.service
+++ b/packaging/root/usr/share/oort/systemd/oort-valued.service
@@ -11,7 +11,7 @@ After=syslog.target network.target
 # http://0pointer.de/public/systemd-man/systemd.exec.html
 [Service]
 Type=simple
-EnvironmentFile=/etc/default/oort-valued
+EnvironmentFile=-/etc/default/oort-valued
 ExecStart=/root/go/bin/oort-valued
 
 # it could take a long time to flush data to disk


### PR DESCRIPTION
I want to get the AIO with as few on disk config differences from production nodes, both to keep on disk overrides to a minimum and to keep stale AIO configs from happening. Overrides are in-code and triggered by having a short hostname ending with "-aio".

Also included here is making GenServiceID public so formic can use it to resolve the Syndicate endpoints for subscribing to value/group store rings.
