### PR TITLE
Working on oort-cli

### DIFF
--- a/oort-cli/main.go
+++ b/oort-cli/main.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/gholt/brimtime"
-	"github.com/gholt/ring"
 	"github.com/gholt/store"
 	"github.com/pandemicsyn/ftls"
 	"github.com/pandemicsyn/oort/api"
@@ -21,17 +20,15 @@ import (
 	"google.golang.org/grpc"
 )
 
-var vaddr = flag.String("vhost", "127.0.0.1:6379", "vstore addr")
-var gaddr = flag.String("ghost", "127.0.0.1:6380", "gstore addr")
-var vring = flag.String("vring", "", "vstore ring (instead of vaddr)")
-var gring = flag.String("gring", "", "gstore ring (instead of gaddr)")
+var vdirect = flag.String("vdirect", "", "Use specific direct value store ip:port instead of default SRV replicated value store")
+var gdirect = flag.String("gdirect", "", "Use specific direct group store ip:port instead of default SRV replicated group store")
 var groupmode = flag.Bool("g", false, "whether we're talking to a groupstore instance")
 var tls = flag.Bool("tls", true, "whether the server is speaking tls")
 var insecureSkipVerify = flag.Bool("insecure", false, "whether or not we should verify the cert")
-var mutualtls = flag.Bool("mutualtls", true, "whether or not the server expects mutual tls auth")
-var certfile = flag.String("cert", "/var/lib/oort-value/client.crt", "cert file to use")
-var keyfile = flag.String("key", "/var/lib/oort-value/client.key", "key file to use")
-var cafile = flag.String("ca", "/var/lib/oort-value/ca.pem", "ca file to use")
+var mutualtls = flag.Bool("mutualtls", false, "whether or not the server expects mutual tls auth")
+var certfile = flag.String("cert", "client.crt", "cert file to use")
+var keyfile = flag.String("key", "client.key", "key file to use")
+var cafile = flag.String("ca", "ca.pem", "ca file to use")
 
 var (
 	prompt    = "> "
@@ -327,19 +324,12 @@ func (c *Client) getValueClient() error {
 		}
 		opts = append(opts, opt)
 	}
-	if c.vring == "" {
-		c.vstore, err = api.NewValueStore(c.vaddr, 10, opts...)
+	if c.vdirect != "" {
+		c.vstore, err = api.NewValueStore(c.vdirect, 10, opts...)
 	} else {
-		var f *os.File
-		f, err = os.Open(c.vring)
-		if err == nil {
-			var r ring.Ring
-			r, err = ring.LoadRing(f)
-			if err == nil {
-				s := api.NewReplValueStore(&api.ReplValueStoreConfig{AddressIndex: 2, GRPCOpts: opts})
-				s.SetRing(r)
-				c.vstore = s
-			}
+		c.vstore = api.NewReplValueStore(&api.ReplValueStoreConfig{AddressIndex: 2, GRPCOpts: opts, RingServerGRPCOpts: opts})
+		if err := c.vstore.Startup(context.Background()); err != nil {
+			return fmt.Errorf("Unable to start value store client: %s", err)
 		}
 	}
 	if err != nil {
@@ -364,19 +354,12 @@ func (c *Client) getGroupClient() error {
 		}
 		opts = append(opts, opt)
 	}
-	if c.gring == "" {
-		c.gstore, err = api.NewGroupStore(c.gaddr, 10, opts...)
+	if c.gdirect != "" {
+		c.gstore, err = api.NewGroupStore(c.gdirect, 10, opts...)
 	} else {
-		var f *os.File
-		f, err = os.Open(c.gring)
-		if err == nil {
-			var r ring.Ring
-			r, err = ring.LoadRing(f)
-			if err == nil {
-				s := api.NewReplGroupStore(&api.ReplGroupStoreConfig{AddressIndex: 2, GRPCOpts: opts})
-				s.SetRing(r)
-				c.gstore = s
-			}
+		c.gstore = api.NewReplGroupStore(&api.ReplGroupStoreConfig{AddressIndex: 2, GRPCOpts: opts, RingServerGRPCOpts: opts})
+		if err := c.gstore.Startup(context.Background()); err != nil {
+			return fmt.Errorf("Unable to start group store client: %s", err)
 		}
 	}
 	if err != nil {
@@ -387,14 +370,12 @@ func (c *Client) getGroupClient() error {
 
 // Client ...
 type Client struct {
-	vaddr  string
-	gaddr  string
-	vring  string
-	gring  string
-	gmode  bool
-	vconn  *grpc.ClientConn
-	vstore store.ValueStore
-	gstore store.GroupStore
+	vdirect string
+	gdirect string
+	gmode   bool
+	vconn   *grpc.ClientConn
+	vstore  store.ValueStore
+	gstore  store.GroupStore
 }
 
 func main() {
@@ -410,11 +391,9 @@ func main() {
 	}
 
 	client := Client{
-		vaddr: *vaddr,
-		gaddr: *gaddr,
-		vring: *vring,
-		gring: *gring,
-		gmode: *groupmode,
+		vdirect: *vdirect,
+		gdirect: *gdirect,
+		gmode:   *groupmode,
 	}
 	sm := "value"
 	if client.gmode {


### PR DESCRIPTION
I changed the -mutualtls default back to false because having it default to true made it a useless option since the option sets it to true. I thought about changing it to -nomutualtls or something but I'll leave that up to you. I just needed the option to do *something* so I could test things out.

This works with replicated stores via the syndicate ring service now, for me at least using -mutualtls.

I know you were talking about revisiting what needs mutualtls and what shouldn't have it, so I'm sure some of this is subject to change.

Also, there are separate grpc opts for the syndicate ring service connection and the actual connections to the stores. Probably need to make separate options to control each, unless it ends up they should always stay the same.